### PR TITLE
Suppress warnings for OneOfBase

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,9 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Osx
+.DS_Store
+
+# Rider
+.idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "OneOf"]
+	path = OneOf
+	url = https://github.com/mcintyre321/OneOf.git

--- a/OneOfDiagnosticSuppressor.Tests/CodeHelper.cs
+++ b/OneOfDiagnosticSuppressor.Tests/CodeHelper.cs
@@ -1,16 +1,85 @@
 ﻿namespace SvSoft.OneOf.Analyzers.SwitchDiagnosticSuppression;
 static class CodeHelper
 {
-    public static string WrapInNamespaceAndUsingAndClass(string code) => $@"
+    public static string WrapInNamespaceAndUsing(string code) => $@"
 using OneOf;
 using System;
 
 namespace MyCode
 {{
-    static class SwitchTest
-    {{
-        {code}
-    }}
+    {code}
 }}
 ";
+
+    public static string SwitchExpressionOneOfVariationsTemplate(string typeParams, string returnType, string switchArms)
+    {
+        return WrapInNamespaceAndUsing(@$"
+[GenerateOneOf]
+public partial class GeneratedOneOf: OneOfBase<{typeParams}>
+{{
+    public {returnType} DoSwitch()
+    {{
+        return this.Value switch
+        {{
+            {switchArms}
+        }};
+    }}
+}}
+
+static class SwitchTest
+{{
+    public static {returnType} DoSwitch(OneOf<{typeParams}> oneof)
+    {{
+        return oneof.Value switch
+        {{
+            {switchArms}
+        }};
+    }}
+
+    public static {returnType} DoSwitch(GeneratedOneOf oneof)
+    {{
+        return oneof.Value switch
+        {{
+            {switchArms}
+        }};
+    }}
+}}
+");
+    }
+    
+    public static string SwitchStatementOneOfVariationsTemplate(string typeParams, string switchArms)
+    {
+        return WrapInNamespaceAndUsing(@$"
+[GenerateOneOf]
+public partial class GeneratedOneOf: OneOfBase<{typeParams}>
+{{
+    public void DoSwitch()
+    {{
+        switch (this.Value)
+        {{
+            {switchArms}
+        }};
+    }}
+}}
+
+static class SwitchTest
+{{
+    public static void DoSwitch(OneOf<{typeParams}> oneof)
+    {{
+        switch (oneof.Value)
+        {{
+            {switchArms}
+        }};
+    }}
+
+    public static void DoSwitch(GeneratedOneOf oneof)
+    {{
+        switch (oneof.Value)
+        {{
+            {switchArms}
+        }};
+    }}
+}}
+");
+    }
 }

--- a/OneOfDiagnosticSuppressor.Tests/CompilationHelper.cs
+++ b/OneOfDiagnosticSuppressor.Tests/CompilationHelper.cs
@@ -2,6 +2,8 @@
 using Microsoft.CodeAnalysis.CSharp;
 using System;
 using System.Reflection;
+using System.Threading;
+using OneOf.SourceGenerator;
 
 namespace SvSoft.OneOf.Analyzers.SwitchDiagnosticSuppression;
 static class CompilationHelper
@@ -14,7 +16,7 @@ static class CompilationHelper
             ? null
             : new[] { CSharpSyntaxTree.ParseText(code) };
 
-        return CSharpCompilation.Create(
+        var compilation = CSharpCompilation.Create(
             Guid.NewGuid().ToString("N"),
             syntaxTrees,
             references: new MetadataReference[]
@@ -28,5 +30,12 @@ static class CompilationHelper
                 OutputKind.DynamicallyLinkedLibrary,
                 reportSuppressedDiagnostics: true,
                 nullableContextOptions: nullableContextOptions));
+
+        CSharpGeneratorDriver.Create(new OneOfGenerator())
+            .RunGeneratorsAndUpdateCompilation(compilation, out var compilationWithGeneration, out var generatorDiagnostics, CancellationToken.None);
+
+        _ = generatorDiagnostics;
+
+        return compilationWithGeneration;
     }
 }

--- a/OneOfDiagnosticSuppressor.Tests/DiagnosticSuppressorAnalyer.cs
+++ b/OneOfDiagnosticSuppressor.Tests/DiagnosticSuppressorAnalyer.cs
@@ -51,8 +51,12 @@ public static class DiagnosticSuppressorAnalyer
             compilationErrors = compilationWithWarnings.GetDiagnostics();
         }
 
+        static bool IsNonHiddenError(Diagnostic d)
+            => d.Severity != DiagnosticSeverity.Hidden
+                && (d.Location.SourceTree != null && !d.Location.SourceTree.FilePath.EndsWith(".g.cs")); // ignore generated files
+
         ImmutableArray<Diagnostic> nonHiddenErrors = compilationErrors
-            .Where(d => d.Severity != DiagnosticSeverity.Hidden)
+            .Where(IsNonHiddenError)
             .ToImmutableArray();
 
         ImmutableArray<Diagnostic> suppressibleErrors = nonHiddenErrors
@@ -67,7 +71,7 @@ public static class DiagnosticSuppressorAnalyer
         ImmutableArray<Diagnostic> analyzerErrors = await compilationWithSuppressor.GetAllDiagnosticsAsync().ConfigureAwait(false);
 
         nonHiddenErrors = analyzerErrors
-            .Where(d => d.Severity != DiagnosticSeverity.Hidden)
+            .Where(IsNonHiddenError)
             .ToImmutableArray();
 
         Assert.That(nonHiddenErrors, Is.Not.Empty);

--- a/OneOfDiagnosticSuppressor.Tests/OneOfDiagnosticSuppressor.Tests.csproj
+++ b/OneOfDiagnosticSuppressor.Tests/OneOfDiagnosticSuppressor.Tests.csproj
@@ -38,4 +38,13 @@
     <ProjectReference Include="..\OneOfDiagnosticSuppressor\OneOfDiagnosticSuppressor.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\OneOf\OneOf.SourceGenerator\GeneratorDiagnosticDescriptors.cs">
+      <Link>GeneratorDiagnosticDescriptors.cs</Link>
+    </Compile>
+    <Compile Include="..\OneOf\OneOf.SourceGenerator\OneOfGenerator.cs">
+      <Link>OneOfGenerator.cs</Link>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
+++ b/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
@@ -31,15 +31,10 @@ class SwitchExpressionSuppressorTests
     [Test]
     public Task When_not_all_type_arguments_are_matched_Then_do_not_suppress()
     {
-        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static int DoSwitch(OneOf<int, string> oneof)
-{
-    return oneof.Value switch
-    {
-        int => 0
-    };
-}
-");
+        var code = CodeHelper.SwitchExpressionOneOfVariationsTemplate(
+            typeParams: "int, string",
+            returnType: "int",
+            switchArms: "int => 0");
 
         return EnsureNotSuppressed(code, NullableContextOptions.Enable);
     }
@@ -47,16 +42,11 @@ public static int DoSwitch(OneOf<int, string> oneof)
     [Test]
     public Task When_nullable_is_disabled_And_type_arguments_include_reference_type_And_null_is_not_matched_Then_do_not_suppress()
     {
-        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static int DoSwitch(OneOf<int, string> oneof)
-{
-    return oneof.Value switch
-    {
-        int => 0,
-        string => 1
-    };
-}
-");
+        var code = CodeHelper.SwitchExpressionOneOfVariationsTemplate(
+            typeParams: "int, string",
+            returnType: "int",
+            switchArms: @"int => 0,
+                          string => 1");
 
         return EnsureNotSuppressed(code, NullableContextOptions.Disable);
     }
@@ -64,16 +54,11 @@ public static int DoSwitch(OneOf<int, string> oneof)
     [Test]
     public Task When_nullable_is_disabled_And_type_arguments_only_include_nonnullable_value_types_And_null_is_not_matched_Then_suppress()
     {
-        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static int DoSwitch(OneOf<int, bool> oneof)
-{
-    return oneof.Value switch
-    {
-        int => 0,
-        bool => 1
-    };
-}
-");
+        var code = CodeHelper.SwitchExpressionOneOfVariationsTemplate(
+            typeParams: "int, bool",
+            returnType: "int",
+            switchArms: @"int => 0,
+                          bool => 1");
 
         return EnsureSuppressed(code, NullableContextOptions.Disable);
     }
@@ -81,16 +66,11 @@ public static int DoSwitch(OneOf<int, bool> oneof)
     [Test]
     public Task When_all_type_arguments_are_matched_Then_suppress()
     {
-        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static int DoSwitch(OneOf<int, string> oneof)
-{
-    return oneof.Value switch
-    {
-        int => 0,
-        string => 1
-    };
-}
-");
+        var code = CodeHelper.SwitchExpressionOneOfVariationsTemplate(
+            typeParams: "int, string",
+            returnType: "int",
+            switchArms: @"int => 0,
+                          string => 1");
 
         return EnsureSuppressed(code, NullableContextOptions.Enable);
     }
@@ -98,84 +78,87 @@ public static int DoSwitch(OneOf<int, string> oneof)
     [Test]
     public Task When_Value_property_is_nested_Then_suppress()
     {
-        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public class Wrapper<T> { public Wrapper(T inner) => Inner = inner; public T Inner { get; set; } }
-    
-public static int DoSwitch(Wrapper<Wrapper<OneOf<int, string>>> wrapper)
-{
-    return wrapper.Inner.Inner.Value switch
-    {
-        int => 0,
-        string => 1
-    };
-}
+        var typeParams = "int, string";
+        var returnType = "int";
+        var switchArms = @"int => 0,
+                          string => 1";
+
+        var code = CodeHelper.WrapInNamespaceAndUsing(@$"
+[GenerateOneOf]
+public partial class GeneratedOneOf: OneOfBase<{typeParams}> {{ }}
+
+static class SwitchTest
+{{
+    public class Wrapper<T> {{ public Wrapper(T inner) => Inner = inner; public T Inner {{ get; set; }} }}
+
+    public static {returnType} DoSwitch(Wrapper<Wrapper<OneOf<{typeParams}>>> wrapper)
+    {{
+        return wrapper.Inner.Inner.Value switch
+        {{
+            {switchArms}
+        }};
+    }}
+
+    public static {returnType} DoSwitch(Wrapper<Wrapper<GeneratedOneOf>> wrapper)
+    {{
+        return wrapper.Inner.Inner.Value switch
+        {{
+            {switchArms}
+        }};
+    }}
+}}
 ");
+
         return EnsureSuppressed(code, NullableContextOptions.Enable);
     }
 
     [Test]
     public Task When_type_arguments_include_nullable_value_types_and_null_is_not_matched_Then_do_not_suppress()
     {
-        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static int DoSwitch(OneOf<int?, string> oneof)
-{
-    return oneof.Value switch
-    {
-        int => 0,
-        string => 1
-    };
-}
-");
+        var code = CodeHelper.SwitchExpressionOneOfVariationsTemplate(
+            typeParams: "int?, string",
+            returnType: "int",
+            switchArms: @"int => 0,
+                          string => 1");
+
         return EnsureNotSuppressed(code, NullableContextOptions.Enable);
     }
 
     [Test]
     public Task When_type_arguments_include_nullable_reference_types_and_null_is_not_matched_Then_do_not_suppress()
     {
-        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static int DoSwitch(OneOf<int, string?> oneof)
-{
-    return oneof.Value switch
-    {
-        int => 0,
-        string => 1
-    };
-}
-");
+        var code = CodeHelper.SwitchExpressionOneOfVariationsTemplate(
+            typeParams: "int, string?",
+            returnType: "int",
+            switchArms: @"int => 0,
+                          string => 1");
+
         return EnsureNotSuppressed(code, NullableContextOptions.Enable);
     }
 
     [Test]
     public Task When_type_arguments_include_nullable_value_types_and_null_is_matched_Then_suppress()
     {
-        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static int DoSwitch(OneOf<int?, string> oneof)
-{
-    return oneof.Value switch
-    {
-        int => 0,
-        string => 1,
-        null => 2
-    };
-}
-");
+        var code = CodeHelper.SwitchExpressionOneOfVariationsTemplate(
+            typeParams: "int?, string",
+            returnType: "int",
+            switchArms: @"int => 0,
+                          string => 1,
+                          null => 2");
+
         return EnsureSuppressed(code, NullableContextOptions.Enable);
     }
 
     [Test]
     public Task When_type_arguments_include_nullable_reference_types_and_null_is_matched_Then_suppress()
     {
-        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static int DoSwitch(OneOf<int, string?> oneof)
-{
-    return oneof.Value switch
-    {
-        int => 0,
-        string => 1,
-        null => 2
-    };
-}
-");
+        var code = CodeHelper.SwitchExpressionOneOfVariationsTemplate(
+            typeParams: "int, string?",
+            returnType: "int",
+            switchArms: @"int => 0,
+                          string => 1,
+                          null => 2");
+
         return EnsureSuppressed(code, NullableContextOptions.Enable);
     }
 }

--- a/OneOfDiagnosticSuppressor/SwitchStatementSuppressor.cs
+++ b/OneOfDiagnosticSuppressor/SwitchStatementSuppressor.cs
@@ -50,6 +50,7 @@ public sealed class SwitchStatementSuppressor : DiagnosticSuppressor
             {
                 IdentifierNameSyntax id => id,
                 MemberAccessExpressionSyntax { Name: IdentifierNameSyntax id } => id,
+                ThisExpressionSyntax v  => v as ExpressionSyntax,
                 _ => null
             };
 
@@ -60,34 +61,33 @@ public sealed class SwitchStatementSuppressor : DiagnosticSuppressor
 
             var switcheeModel = context.GetSemanticModel(switchee.SyntaxTree);
             var valueSourceInfo = switcheeModel.GetTypeInfo(valueSource);
-            var valueSourceType = valueSourceInfo.Type;
-            IEnumerable<INamedTypeSymbol> subtypes;
-            if (valueSourceType is INamedTypeSymbol t)
+            
+            static INamedTypeSymbol? AsOneOfSymbol(ITypeSymbol? t, string name)
             {
-                if (t.Name.Equals("OneOf", StringComparison.Ordinal) &&
+                if (t != null &&
+                    t.Name.Equals(name, StringComparison.Ordinal) &&
                     t.ContainingAssembly.Name.Equals("OneOf", StringComparison.Ordinal))
                 {
-                    var namedTypeArguments = t.TypeArguments.OfType<INamedTypeSymbol>().ToArray();
-                    if (namedTypeArguments.Length == t.TypeArguments.Length)
-                    {
-                        subtypes = namedTypeArguments;
-                    }
-                    else
-                    {
-                        return;
-                    }
+                    return t as INamedTypeSymbol;
                 }
-                else
-                {
-                    return;
-                }
+
+                return null;
             }
-            else
+            
+            var oneOfSymbol = AsOneOfSymbol(valueSourceInfo.Type?.BaseType, "OneOfBase")
+                              ?? AsOneOfSymbol(valueSourceInfo.Type, "OneOf");
+
+            var namedTypeArguments = oneOfSymbol?.TypeArguments.OfType<INamedTypeSymbol>().ToArray();
+            IEnumerable<INamedTypeSymbol>? subtypes = namedTypeArguments?.Length == oneOfSymbol?.TypeArguments.Length
+                ? namedTypeArguments
+                : null;
+
+            if (oneOfSymbol == null || subtypes == null)
             {
                 return;
             }
 
-            bool mustHandleNullCase = t.TypeArgumentNullableAnnotations.Any(a => a is not NullableAnnotation.NotAnnotated);
+            bool mustHandleNullCase = oneOfSymbol.TypeArgumentNullableAnnotations.Any(a => a is not NullableAnnotation.NotAnnotated);
 
             var sections = switchStatement.Sections;
 


### PR DESCRIPTION
OneOf supports [auto generating](https://github.com/mcintyre321/OneOf#oneofbase-source-generation) class implementations based on an attribute. Since it's basically almost the same as the OneOf type, I thought this could be added just in case.

The compilation in the test project now news up the required generator: `new OneOfGenerator()`. I couldn't figure out a way to reference the class via the nuget package, as it seems like generators are somehow hidden? Instead, the OneOfGenerator is added by directly including the .cs files via a git submodule.

While coding this I realized using the auto generating feature doesn't add that much value over just using `ClosedTypeHierarchyDiagnosticSuppressor` with an abstract base class, but can't hurt to add this right?