### PR TITLE
Supporting invocations/await for the OneOf-Value

### DIFF
--- a/OneOfDiagnosticSuppressor.Tests/CodeHelper.cs
+++ b/OneOfDiagnosticSuppressor.Tests/CodeHelper.cs
@@ -4,6 +4,7 @@ static class CodeHelper
     public static string WrapInNamespaceAndUsingAndClass(string code) => $@"
 using OneOf;
 using System;
+using System.Threading.Tasks;
 
 namespace MyCode
 {{

--- a/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
+++ b/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
@@ -224,6 +224,23 @@ public static int DoSwitch(OneOf<int, string?> oneof)
         var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
 public static async Task<int> DoSwitch()
 {
+    Task<OneOf<int, string>> task = Task.FromResult(OneOf<int, string>.FromT0(0));
+    return (await task).Value switch
+    {
+        int => 1,
+        string => 2,
+    };
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
+
+    [Test]
+    public Task When_Value_property_is_from_await_identifier_expression_declared_as_var_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static async Task<int> DoSwitch()
+{
     var task = Task.FromResult(OneOf<int, string>.FromT0(0));
     return (await task).Value switch
     {

--- a/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
+++ b/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
@@ -238,4 +238,34 @@ public static int DoSwitch()
 ");
         return EnsureSuppressed(code, NullableContextOptions.Enable);
     }
+
+    [Test]
+    public Task When_switch_expressions_are_nested_Then_invocations_work_directly_without_an_intermediate_variable()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static OneOf<int, string> OneOfFunc()
+{
+    return 1;
+}
+
+public static OneOf<int, string> OneOfFunc2(int i)
+{
+    return i;
+}
+
+public static int DoSwitch()
+{
+    return OneOfFunc().Value switch
+    {
+        string => 1,
+        int i => OneOfFunc2(i).Value switch
+        {
+            string => 3,
+            int => 4,
+        },
+    };
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
 }

--- a/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
+++ b/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
@@ -196,4 +196,46 @@ public static int DoSwitch(OneOf<int, string?> oneof)
 ");
         return EnsureSuppressed(code, NullableContextOptions.Enable);
     }
+
+    [Test]
+    public Task When_Value_property_is_from_await_expression_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static Task<OneOf<int, string>> AsyncFunc()
+{
+    return Task.FromResult<OneOf<int, string>>(1);
+}
+
+public static async Task<int> DoSwitch()
+{
+    return (await AsyncFunc()).Value switch
+    {
+        int => 1,
+        string => 2,
+    };
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
+
+    [Test]
+    public Task When_Value_property_is_from_invocation_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static OneOf<int, string> OneOfFunc()
+{
+    return 1;
+}
+
+public static int DoSwitch()
+{
+    return OneOfFunc().Value switch
+    {
+        int => 1,
+        string => 2,
+    };
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
 }

--- a/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
+++ b/OneOfDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
@@ -132,6 +132,27 @@ public static int DoSwitch(Wrapper<Wrapper<OneOf<int, string>>> wrapper)
     }
 
     [Test]
+    public Task When_Value_property_is_from_invocation_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static OneOf<int, string> OneOfFunc()
+{
+    return 1;
+}
+
+public static int DoSwitch()
+{
+    return OneOfFunc().Value switch
+    {
+        int => 1,
+        string => 2,
+    };
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
+
+    [Test]
     public Task When_type_arguments_include_nullable_value_types_and_null_is_not_matched_Then_do_not_suppress()
     {
         var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
@@ -198,17 +219,13 @@ public static int DoSwitch(OneOf<int, string?> oneof)
     }
 
     [Test]
-    public Task When_Value_property_is_from_await_expression_Then_suppress()
+    public Task When_Value_property_is_from_await_identifier_expression_Then_suppress()
     {
         var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static Task<OneOf<int, string>> AsyncFunc()
-{
-    return Task.FromResult<OneOf<int, string>>(1);
-}
-
 public static async Task<int> DoSwitch()
 {
-    return (await AsyncFunc()).Value switch
+    var task = Task.FromResult(OneOf<int, string>.FromT0(0));
+    return (await task).Value switch
     {
         int => 1,
         string => 2,
@@ -219,17 +236,55 @@ public static async Task<int> DoSwitch()
     }
 
     [Test]
-    public Task When_Value_property_is_from_invocation_Then_suppress()
+    public Task When_Value_property_if_from_nested_await_expression_Then_suppress()
     {
         var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static OneOf<int, string> OneOfFunc()
+static Task<Task<OneOf<int, string>>> Func()
 {
-    return 1;
+    return Task.FromResult(Task.FromResult(OneOf<int, string>.FromT0(0)));
 }
 
-public static int DoSwitch()
+public static async Task<int> DoSwitch()
 {
-    return OneOfFunc().Value switch
+    return (await await Func()).Value switch
+    {
+        int => 1,
+        string => 2,
+    };
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
+
+    [Test]
+    public Task When_Value_property_is_from_await_member_expression_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static async Task<int> DoSwitch()
+{
+    var obj = new { Task = Task.FromResult(OneOf<int, string>.FromT0(0)) };
+    return (await obj.Task).Value switch
+    {
+        int => 1,
+        string => 2,
+    };
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
+
+    [Test]
+    public Task When_Value_property_is_from_await_invocation_expression_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static Task<OneOf<int, string>> AsyncFunc()
+{
+    return Task.FromResult<OneOf<int, string>>(1);
+}
+
+public static async Task<int> DoSwitch()
+{
+    return (await AsyncFunc()).Value switch
     {
         int => 1,
         string => 2,

--- a/OneOfDiagnosticSuppressor.Tests/SwitchStatementSuppressorTests.cs
+++ b/OneOfDiagnosticSuppressor.Tests/SwitchStatementSuppressorTests.cs
@@ -196,4 +196,52 @@ public static void DoSwitch(OneOf<int, string?> oneof)
 ");
         return EnsureSuppressed(code, NullableContextOptions.Enable);
     }
+
+    [Test]
+    public Task When_Value_property_is_from_await_expression_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static Task<OneOf<int, string>> AsyncFunc()
+{
+    return Task.FromResult<OneOf<int, string>>(1);
+}
+
+public static async Task DoSwitch()
+{
+    switch ((await AsyncFunc()).Value)
+    {
+        case int:
+            break;
+
+        case string:
+            break;
+    }
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
+
+    [Test]
+    public Task When_Value_property_is_from_invocation_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static OneOf<int, string> OneOfFunc()
+{
+    return 1;
+}
+
+public static void DoSwitch()
+{
+    switch (OneOfFunc().Value)
+    {
+        case int:
+            break;
+
+        case string:
+            break;
+    }
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
 }

--- a/OneOfDiagnosticSuppressor.Tests/SwitchStatementSuppressorTests.cs
+++ b/OneOfDiagnosticSuppressor.Tests/SwitchStatementSuppressorTests.cs
@@ -122,6 +122,30 @@ public static void DoSwitch(Wrapper<Wrapper<OneOf<int, string>>> wrapper)
     }
 
     [Test]
+    public Task When_Value_property_is_from_invocation_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static OneOf<int, string> OneOfFunc()
+{
+    return 1;
+}
+
+public static void DoSwitch()
+{
+    switch (OneOfFunc().Value)
+    {
+        case int:
+            break;
+
+        case string:
+            break;
+    }
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
+
+    [Test]
     public Task When_type_arguments_include_nullable_value_types_and_null_is_not_matched_Then_do_not_suppress()
     {
         var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
@@ -198,17 +222,13 @@ public static void DoSwitch(OneOf<int, string?> oneof)
     }
 
     [Test]
-    public Task When_Value_property_is_from_await_expression_Then_suppress()
+    public Task When_Value_property_is_from_await_identifier_expression_Then_suppress()
     {
         var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static Task<OneOf<int, string>> AsyncFunc()
-{
-    return Task.FromResult<OneOf<int, string>>(1);
-}
-
 public static async Task DoSwitch()
 {
-    switch ((await AsyncFunc()).Value)
+    var task = Task.FromResult(OneOf<int, string>.FromT0(0));
+    switch ((await task).Value)
     {
         case int:
             break;
@@ -222,17 +242,61 @@ public static async Task DoSwitch()
     }
 
     [Test]
-    public Task When_Value_property_is_from_invocation_Then_suppress()
+    public Task When_Value_property_if_from_nested_await_expression_Then_suppress()
     {
         var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
-public static OneOf<int, string> OneOfFunc()
+static Task<Task<OneOf<int, string>>> Func()
 {
-    return 1;
+    return Task.FromResult(Task.FromResult(OneOf<int, string>.FromT0(0)));
 }
 
-public static void DoSwitch()
+public static async Task DoSwitch()
 {
-    switch (OneOfFunc().Value)
+    switch ((await await Func()).Value)
+    {
+        case int:
+            break;
+
+        case string:
+            break;
+    }
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
+
+    [Test]
+    public Task When_Value_property_is_from_await_member_expression_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static async Task DoSwitch()
+{
+    var obj = new { Task = Task.FromResult(OneOf<int, string>.FromT0(0)) };
+    switch ((await obj.Task).Value)
+    {
+        case int:
+            break;
+
+        case string:
+            break;
+    }
+}
+");
+        return EnsureSuppressed(code, NullableContextOptions.Enable);
+    }
+
+    [Test]
+    public Task When_Value_property_is_from_await_invocation_expression_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespaceAndUsingAndClass(@"
+public static Task<OneOf<int, string>> AsyncFunc()
+{
+    return Task.FromResult<OneOf<int, string>>(1);
+}
+
+public static async Task DoSwitch()
+{
+    switch ((await AsyncFunc()).Value)
     {
         case int:
             break;

--- a/OneOfDiagnosticSuppressor/ExpressionHelper.cs
+++ b/OneOfDiagnosticSuppressor/ExpressionHelper.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis;
+
+namespace SvSoft.OneOf.Analyzers.SwitchDiagnosticSuppression;
+
+static class ExpressionHelper
+{
+    static ExpressionSyntax GetUnparenthesizedExpression(ExpressionSyntax expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax parenthesizedExpression)
+            expression = parenthesizedExpression.Expression;
+
+        return expression;
+    }
+
+    static ITypeSymbol? GetTypeSymbolFromIdentifier(SemanticModel model, IdentifierNameSyntax syntax)
+        => model.GetTypeInfo(syntax).Type;
+
+    static ITypeSymbol? GetTypeSymbolFromInvocation(SemanticModel model, InvocationExpressionSyntax invocation, bool expectTaskReturnType)
+    {
+        var invokedSymbol = model.GetSymbolInfo(invocation);
+        if (invokedSymbol.Symbol is not IMethodSymbol methodSymbol || methodSymbol.ReturnType is not INamedTypeSymbol returnTypeSymbol)
+        {
+            return null;
+        }
+
+        if (expectTaskReturnType)
+        {
+            if (returnTypeSymbol.TypeArguments.Length != 1)
+            {
+                return null;
+            }
+
+            return returnTypeSymbol.TypeArguments[0];
+        }
+
+        return returnTypeSymbol;
+    }
+
+    static ITypeSymbol? GetTypeSymbolFromAwaitExpression(SemanticModel model, AwaitExpressionSyntax awaitSyntax)
+    {
+        return GetUnparenthesizedExpression(awaitSyntax.Expression) switch
+        {
+            IdentifierNameSyntax id => GetTypeSymbolFromIdentifier(model, id),
+            MemberAccessExpressionSyntax { Name: IdentifierNameSyntax id } => GetTypeSymbolFromIdentifier(model, id),
+            InvocationExpressionSyntax invocation => GetTypeSymbolFromInvocation(model, invocation, expectTaskReturnType: true),
+            _ => null,
+        };
+    }
+
+    public static ITypeSymbol? GetTypeOfSwitchExpressionOrStatement(SemanticModel model, ExpressionSyntax switchSyntaxExpression)
+    {
+        if (switchSyntaxExpression is not MemberAccessExpressionSyntax { Name.Identifier.Text: "Value" } valueAccess)
+        {
+            return null;
+        }
+
+        return GetUnparenthesizedExpression(valueAccess.Expression) switch
+        {
+            IdentifierNameSyntax id => GetTypeSymbolFromIdentifier(model, id),
+            MemberAccessExpressionSyntax { Name: IdentifierNameSyntax id } => GetTypeSymbolFromIdentifier(model, id),
+            InvocationExpressionSyntax invocation => GetTypeSymbolFromInvocation(model, invocation, expectTaskReturnType: false),
+            AwaitExpressionSyntax awaitSyntax => GetTypeSymbolFromAwaitExpression(model, awaitSyntax),
+            _ => null,
+        };
+    }
+}

--- a/OneOfDiagnosticSuppressor/ExpressionHelper.cs
+++ b/OneOfDiagnosticSuppressor/ExpressionHelper.cs
@@ -5,26 +5,16 @@ namespace SvSoft.OneOf.Analyzers.SwitchDiagnosticSuppression;
 
 static class ExpressionHelper
 {
-    static ExpressionSyntax GetUnparenthesizedExpression(ExpressionSyntax expression)
-    {
-        while (expression is ParenthesizedExpressionSyntax parenthesizedExpression)
-            expression = parenthesizedExpression.Expression;
+    const string OneOfValuePropertyName = "Value";
 
-        return expression;
-    }
-
-    static ITypeSymbol? GetTypeOfTask(ITypeSymbol? taskSymbol)
+    public static ITypeSymbol? GetTypeOfValueSource(SemanticModel model, ExpressionSyntax switcheeSyntax)
     {
-        if (taskSymbol is not INamedTypeSymbol namedTaskSymbol)
-        {
-            return null;
-        }
-        if (namedTaskSymbol.TypeArguments.Length != 1)
+        if (switcheeSyntax is not MemberAccessExpressionSyntax { Name.Identifier.Text: OneOfValuePropertyName } valueAccess)
         {
             return null;
         }
 
-        return namedTaskSymbol.TypeArguments[0];
+        return GetTypeSymbolFromExpression(model, valueAccess.Expression);
     }
 
     static ITypeSymbol? GetTypeSymbolFromExpression(SemanticModel model, ExpressionSyntax expression)
@@ -39,13 +29,28 @@ static class ExpressionHelper
         };
     }
 
-    public static ITypeSymbol? GetTypeOfSwitchExpressionOrStatement(SemanticModel model, ExpressionSyntax switchSyntaxExpression)
+    static ExpressionSyntax GetUnparenthesizedExpression(ExpressionSyntax expression)
     {
-        if (switchSyntaxExpression is not MemberAccessExpressionSyntax { Name.Identifier.Text: "Value" } valueAccess)
+        while (expression is ParenthesizedExpressionSyntax parenthesizedExpression)
+        {
+            expression = parenthesizedExpression.Expression;
+        }
+
+        return expression;
+    }
+
+    static ITypeSymbol? GetTypeOfTask(ITypeSymbol? taskSymbol)
+    {
+        if (taskSymbol is not INamedTypeSymbol namedTaskSymbol)
         {
             return null;
         }
 
-        return GetTypeSymbolFromExpression(model, valueAccess.Expression);
+        if (namedTaskSymbol.TypeArguments.Length != 1)
+        {
+            return null;
+        }
+
+        return namedTaskSymbol.TypeArguments[0];
     }
 }

--- a/OneOfDiagnosticSuppressor/SwitchExpressionSuppressor.cs
+++ b/OneOfDiagnosticSuppressor/SwitchExpressionSuppressor.cs
@@ -43,7 +43,7 @@ public sealed class SwitchExpressionSuppressor : DiagnosticSuppressor
             var switchExpression = node.DescendantNodesAndSelf().OfType<SwitchExpressionSyntax>().FirstOrDefault();
 
             SemanticModel switcheeModel = context.GetSemanticModel(switchExpression.GoverningExpression.SyntaxTree);
-            var valueSourceType = ExpressionHelper.GetTypeOfSwitchExpressionOrStatement(switcheeModel, switchExpression.GoverningExpression);
+            var valueSourceType = ExpressionHelper.GetTypeOfValueSource(switcheeModel, switchExpression.GoverningExpression);
 
             if (!(valueSourceType is INamedTypeSymbol t && OneOfTypeHelper.GetOneOfSubTypes(t) is IEnumerable<INamedTypeSymbol> subtypes))
             {

--- a/OneOfDiagnosticSuppressor/SwitchStatementSuppressor.cs
+++ b/OneOfDiagnosticSuppressor/SwitchStatementSuppressor.cs
@@ -41,7 +41,7 @@ public sealed class SwitchStatementSuppressor : DiagnosticSuppressor
             }
 
             SemanticModel switcheeModel = context.GetSemanticModel(switchStatement.Expression.SyntaxTree);
-            var valueSourceType = ExpressionHelper.GetTypeOfSwitchExpressionOrStatement(switcheeModel, switchStatement.Expression);
+            var valueSourceType = ExpressionHelper.GetTypeOfValueSource(switcheeModel, switchStatement.Expression);
 
             if (!(valueSourceType is INamedTypeSymbol t && OneOfTypeHelper.GetOneOfSubTypes(t) is IEnumerable<INamedTypeSymbol> subtypes))
             {

--- a/OneOfDiagnosticSuppressor/SwitchStatementSuppressor.cs
+++ b/OneOfDiagnosticSuppressor/SwitchStatementSuppressor.cs
@@ -40,27 +40,8 @@ public sealed class SwitchStatementSuppressor : DiagnosticSuppressor
                 return;
             }
 
-            ExpressionSyntax switchee = switchStatement.Expression;
-            if (switchee is not MemberAccessExpressionSyntax { Name.Identifier.Text: "Value" } valueAccess)
-            {
-                return;
-            }
-
-            var valueSource = valueAccess.Expression switch
-            {
-                IdentifierNameSyntax id => id,
-                MemberAccessExpressionSyntax { Name: IdentifierNameSyntax id } => id,
-                _ => null
-            };
-
-            if (valueSource is null)
-            {
-                return;
-            }
-
-            SemanticModel switcheeModel = context.GetSemanticModel(switchee.SyntaxTree);
-            TypeInfo valueSourceInfo = switcheeModel.GetTypeInfo(valueSource);
-            ITypeSymbol? valueSourceType = valueSourceInfo.Type;
+            SemanticModel switcheeModel = context.GetSemanticModel(switchStatement.Expression.SyntaxTree);
+            var valueSourceType = ExpressionHelper.GetTypeOfSwitchExpressionOrStatement(switcheeModel, switchStatement.Expression);
 
             if (!(valueSourceType is INamedTypeSymbol t && OneOfTypeHelper.GetOneOfSubTypes(t) is IEnumerable<INamedTypeSymbol> subtypes))
             {


### PR DESCRIPTION
Hi,

first of all thanks for making this suppressor. It really makes OneOfs more usable.

I added support for method calls and await expressions to be suppressable. When using this suppressor I often run into the case that we do the following

```csharp
var result = await SomethingAsync();
return result.Value switch
{
    ...
};
```

Less often, we just need to call a method without await. This PR adds support for both cases. I added simple test cases for both (invocation and await) to both suppressors.

```csharp
return (await SomethingAsync()).Value switch
{
    ...
};
```

This also makes nested switch expressions work without (local) functions, which weren't possible before since you never could declare result. I also added a test for this (more as a documentation thing than an actual "does this really work" test)

```csharp
return SomeFunc().Value switch
{
    SomeError => ...,
    Success s => SomeOtherFunc(s).Value switch
    {
       ...
    }
};
```

I moved some common logic for determining the ITypeSymbol of the expression to another helper because it's a bit more code now and inlining that into both suppressors seemed not to be the greatest idea.

It would be great if you could incorporate these changes into a new version of the published package. If you need me to change stuff just tell me what. You can also edit this branch yourself.

Thanks in advance,
David